### PR TITLE
Preload dateparser data before creating coordinator and run feed updates in event loop

### DIFF
--- a/custom_components/ingv_centro_nazionale_terremoti/__init__.py
+++ b/custom_components/ingv_centro_nazionale_terremoti/__init__.py
@@ -2,6 +2,7 @@
 """All credit goes to Malte Franken [@exxamalte]."""
 from collections.abc import Callable
 from datetime import timedelta
+from importlib import import_module, util
 import logging
 
 from aio_quakeml_ingv_centro_nazionale_terremoti_client import (
@@ -81,6 +82,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     radius = entry.options[CONF_RADIUS]
     if hass.config.units is IMPERIAL_SYSTEM:
         radius = METRIC_SYSTEM.length(radius, UnitOfLength.MILES)
+    await _async_preload_dateparser(hass)
     # Create feed entity coordinator for all platforms.
     coordinator = IngvDataUpdateCoordinator(hass=hass, entry=entry, radius_in_km=radius)
     feeds[entry.entry_id] = coordinator
@@ -119,6 +121,18 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Handle an options update."""
     await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def _async_preload_dateparser(hass: HomeAssistant) -> None:
+    """Preload dateparser data to avoid blocking imports in the event loop."""
+    language = hass.config.language or "en"
+    module_names = [f"dateparser.data.date_translation_data.{language}"]
+    if language != "en":
+        module_names.append("dateparser.data.date_translation_data.en")
+    for module_name in module_names:
+        if util.find_spec(module_name) is None:
+            continue
+        await hass.async_add_executor_job(import_module, module_name)
 
 
 class IngvDataUpdateCoordinator(DataUpdateCoordinator):


### PR DESCRIPTION
### Motivation
- Avoid blocking the Home Assistant event loop caused by `dateparser`'s dynamic imports by preloading translation data before creating the coordinator.
- Restore running `IngvCentroNazionaleTerremotiQuakeMLFeedManager.update` in the event loop because the feed client uses async callbacks that must run on the loop for the sensor to function correctly.

### Description
- Add a new helper `async def _async_preload_dateparser(hass: HomeAssistant)` that checks for `dateparser` translation modules with `util.find_spec` and preloads them using `import_module` inside `hass.async_add_executor_job` to avoid blocking the loop.
- Call `await _async_preload_dateparser(hass)` from `async_setup_entry` before creating the `IngvDataUpdateCoordinator` so translation data is ready prior to feed initialization.
- Revert `async_update` to run the feed manager update in the event loop with `await self._feed_manager.update()` so async callbacks from the client execute correctly.
- Import `import_module` and `util` from `importlib` to support the preload logic.

### Testing
- Ok.

------
